### PR TITLE
SYNC: update amss2.md from lecture-python-advanced.myst

### DIFF
--- a/lectures/amss2.md
+++ b/lectures/amss2.md
@@ -20,19 +20,11 @@ kernelspec:
 
 # Fluctuating Interest Rates Deliver Fiscal Insurance
 
-In addition to what's in Anaconda, this lecture will need the following libraries:
-
-```{code-cell} ipython
----
-tags: [hide-output]
----
-!pip install --upgrade quantecon
-```
 
 ## Overview
 
-This lecture extends our investigations of how optimal policies for levying a flat-rate tax on labor income and  issuing government debt depend
-on whether there are complete  markets for debt.
+This lecture studies  how optimal policies for levying a flat-rate tax on labor income  depend
+on whether a government can buy and sell a complete set of one-period-ahead Arrow securities or whether it is instead able to buy or sell  only one-period risk-free debt.  
 
 A Ramsey allocation and Ramsey policy in the AMSS {cite}`aiyagari2002optimal` model described in {doc}`optimal taxation without state-contingent debt <amss>` generally differs
 from a Ramsey allocation and Ramsey policy in the  Lucas-Stokey {cite}`LucasStokey1983` model described in {doc}`optimal taxation with state-contingent debt <opt_tax_recur>`.
@@ -80,6 +72,16 @@ This lecture studies a special  AMSS model in which
 
 In a nutshell, the reason for this striking outcome is that at a particular level of risk-free government **assets**, fluctuations in the one-period risk-free interest
 rate provide the government with complete insurance against stochastically varying government expenditures.
+
+
+In addition to what's in Anaconda, this lecture will need the following libraries:
+
+```{code-cell} ipython
+---
+tags: [hide-output]
+---
+!pip install --upgrade quantecon
+```
 
 Let's start with some imports:
 


### PR DESCRIPTION
Syncs `lectures/amss2.md` with its primary source `lecture-python-advanced.myst` (see #7 for the source mapping).

The lecture-dp copy was last at the initial-setup version (2026-01-14). Upstream commit `8c84d8da` (PR QuantEcon/lecture-python-advanced.myst#312, "Update Tom's edits to AMSS and Calvo Lectures", 2026-02-23) reworked it: Tom's edits to the AMSS recursive-formulation lecture.

After this sync the file is byte-identical to the source. No intersphinx prefixes needed preserving.

🤖 Generated with [Claude Code](https://claude.com/claude-code)