### PR TITLE
SYNC: update amss3.md from lecture-python-advanced.myst

### DIFF
--- a/lectures/amss3.md
+++ b/lectures/amss3.md
@@ -20,14 +20,6 @@ kernelspec:
 
 # Fiscal Risk and Government Debt
 
-In addition to what's in Anaconda, this lecture will need the following libraries:
-
-```{code-cell} ipython
----
-tags: [hide-output]
----
-!pip install --upgrade quantecon
-```
 
 ## Overview
 
@@ -64,7 +56,19 @@ BEGS that we describe below.
 
 We use code constructed in {doc}`Fluctuating Interest Rates Deliver Fiscal Insurance <amss2>`.
 
+```{note}
 **Warning:** Key equations in  {cite}`BEGS1` section III.D carry  typos  that we correct below.
+```
+
+
+In addition to what's in Anaconda, this lecture will need the following libraries:
+
+```{code-cell} ipython
+---
+tags: [hide-output]
+---
+!pip install --upgrade quantecon
+```
 
 Let's start with some imports:
 


### PR DESCRIPTION
Syncs `lectures/amss3.md` with its primary source `lecture-python-advanced.myst` (see #7 for the source mapping).

The lecture-dp copy was last at the initial-setup version (2026-01-14). Upstream commit `8c84d8da` (PR QuantEcon/lecture-python-advanced.myst#312, "Update Tom's edits to AMSS and Calvo Lectures", 2026-02-23) reworked it: Tom's edits to the AMSS fiscal-insurance lecture.

After this sync the file is byte-identical to the source. No intersphinx prefixes needed preserving.

🤖 Generated with [Claude Code](https://claude.com/claude-code)