### PR TITLE
SYNC: update calvo_machine_learn.md from lecture-python-advanced.myst

### DIFF
--- a/lectures/calvo_machine_learn.md
+++ b/lectures/calvo_machine_learn.md
@@ -139,21 +139,11 @@ or
 
 Because $\alpha > 0$,  $0 < \frac{\alpha}{1+\alpha} < 1$.
 
-```{prf:definition}
-:label: square-summable
 
-For  scalar $b_t$, let $L^2$ be the space of sequences
-$\{b_t\}_{t=0}^\infty$ that satisfy 
+We assume that the sequence $\vec \mu = \{\mu_t\}_{t=0}^\infty$ is bounded.
 
-$$
-\sum_{t=0}^\infty  b_t^2 < +\infty
-$$
-
-We say that a sequence that belongs to $L^2$ is **square summable**.
-```
-
-When we assume that the sequence $\vec \mu = \{\mu_t\}_{t=0}^\infty$ is square summable and also require that the sequence $\vec \theta = \{\theta_t\}_{t=0}^\infty$ is square summable,
-the linear difference equation {eq}`eq_grad_old2` can be solved forward to get:
+ 
+Then the linear difference equation {eq}`eq_grad_old2` can be solved forward to get:
 
 ```{math}
 :label: eq_grad_old3


### PR DESCRIPTION
Syncs `lectures/calvo_machine_learn.md` with its primary source `lecture-python-advanced.myst` (see #7 for the source mapping).

The lecture-dp copy was last at the initial-setup version (2026-01-14). Upstream commit `8c84d8da` (PR QuantEcon/lecture-python-advanced.myst#312, "Update Tom's edits to AMSS and Calvo Lectures", 2026-02-23) reworked it: Tom's edits to the Calvo machine-learning lecture.

After this sync the file is byte-identical to the source. No intersphinx prefixes needed preserving.

🤖 Generated with [Claude Code](https://claude.com/claude-code)