### PR TITLE
FIX: resolve short_path cross-references locally in lqcontrol.md

### DIFF
--- a/lectures/lqcontrol.md
+++ b/lectures/lqcontrol.md
@@ -57,7 +57,7 @@ In reading what follows, it will be useful to have some familiarity with
 
 * matrix manipulations
 * vectors of random variables
-* dynamic programming and the Bellman equation (see for example {doc}`this lecture <intro:short_path>` and {doc}`os_stochastic`)
+* dynamic programming and the Bellman equation (see for example {doc}`this lecture <short_path>` and {doc}`os_stochastic`)
 
 For additional reading on LQ control, see, for example,
 
@@ -368,7 +368,7 @@ What's special about the LQ case is that -- as we shall soon see ---  the optima
 ### Solution
 
 To solve the finite horizon LQ problem we can use a dynamic programming
-strategy based on backward induction that is conceptually similar to the approach adopted in {doc}`this lecture <intro:short_path>`.
+strategy based on backward induction that is conceptually similar to the approach adopted in {doc}`this lecture <short_path>`.
 
 For reasons that will soon become clear, we first introduce the notation $J_T(x) = x' R_f x$.
 


### PR DESCRIPTION
`short_path` is a local lecture in lecture-dp (Introduction section in `_toc.yml`), but two `{doc}` references in `lqcontrol.md` linked to it externally via `intro:short_path` (→ intro.quantecon.org). This changes them to bare `short_path` so they resolve to the local lecture-dp page.

- [lqcontrol.md:60](https://github.com/QuantEcon/lecture-dp/blob/main/lectures/lqcontrol.md#L60)
- [lqcontrol.md:371](https://github.com/QuantEcon/lecture-dp/blob/main/lectures/lqcontrol.md#L371)

This is an intentional lecture-dp-specific intersphinx divergence from the `lecture-python.myst` source (where `short_path` doesn't exist locally and the `intro:` prefix is correct). It sits alongside the file's existing `intermediate:kalman` divergence documented in #7.

🤖 Generated with [Claude Code](https://claude.com/claude-code)