### PR TITLE
FIX: resolve short_path cross-reference locally in os.md

### DIFF
--- a/lectures/os.md
+++ b/lectures/os.md
@@ -32,7 +32,7 @@ The main tool we will use to solve the cake eating problem is dynamic programmin
 The following lectures contain background on dynamic programming and might be
 worth reviewing:
 
-* The {doc}`shortest paths lecture <intro:short_path>`
+* The {doc}`shortest paths lecture <short_path>`
 * The {doc}`basic McCall model <mccall_model>`
 * The {doc}`McCall model with separation <mccall_model_with_separation>`
 * The {doc}`McCall model with separation and a continuous wage distribution <mccall_fitted_vfi>`


### PR DESCRIPTION
`short_path` is a local lecture in lecture-dp (Introduction section in `_toc.yml`), but the `{doc}` reference in `os.md` linked to it externally via `intro:short_path` (→ intro.quantecon.org). This changes it to bare `short_path` so it resolves to the local lecture-dp page.

- [os.md:35](https://github.com/QuantEcon/lecture-dp/blob/main/lectures/os.md#L35)

This introduces an intentional lecture-dp-specific intersphinx divergence from the `lecture-python.myst` source (where `short_path` doesn't exist locally and the `intro:` prefix is correct). Noted for #7.

🤖 Generated with [Claude Code](https://claude.com/claude-code)