### PR TITLE
FIX: index fsolve result in un_insure r_error so brentq gets a scalar

### DIFF
--- a/lectures/un_insure.md
+++ b/lectures/un_insure.md
@@ -606,7 +606,7 @@ def r_error(self,r):
     β = self.β
     Ve = self.Ve
 
-    Vu_star = sp.optimize.fsolve(Vu_error_Λ,15000,args = (r))
+    Vu_star = sp.optimize.fsolve(Vu_error_Λ,15000,args = (r))[0]
     a_star = invp_prime(1/(β*(Ve-Vu_star)),r) # Assuming a>0
     return    p(a_star,r) - 0.1
 ```


### PR DESCRIPTION
## Problem

The CI `build` has been failing on `un_insure.md` (also on `main`'s scheduled builds and on every open sync PR):

```
TypeError: only 0-dimensional arrays can be converted to Python scalars
```

This is **not** caused by any of the sync PRs — it's a pre-existing notebook execution error that surfaces on a fresh build with the current `ghcr.io/quantecon/quantecon-build:latest` image (numpy 2.4.4 / scipy 1.17.1).

## Cause

In `r_error`, `sp.optimize.fsolve(...)` returns a length-1 array, so `r_error` returns a shape-`(1,)` array. The outer `sp.optimize.brentq(r_error_Λ, ...)` then coerces that return value to a Python float; under numpy 2.x this raises (older numpy silently accepted 1-element arrays, so cache-warmed builds masked it).

## Fix

```diff
-    Vu_star = sp.optimize.fsolve(Vu_error_Λ,15000,args = (r))
+    Vu_star = sp.optimize.fsolve(Vu_error_Λ,15000,args = (r))[0]
```

Returns a scalar, matching the existing `Vu_aut = sp.optimize.fsolve(...)[0]` call a few lines below.

## Verification

Ran the full `un_insure.md` notebook inside `ghcr.io/quantecon/quantecon-build:latest` (numpy 2.4.4 / scipy 1.17.1): completes end-to-end, calibration result unchanged (`r = 0.000343...`).

## Provenance

`un_insure.md` is sourced from `lecture-python-advanced.myst` (see #7). The same fix is opened upstream as QuantEcon/lecture-python-advanced.myst#327, so a future re-sync stays consistent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)