### PR TITLE
TOC: introduce "Markov Decision Processes" section

### DIFF
--- a/lectures/_toc.yml
+++ b/lectures/_toc.yml
@@ -5,7 +5,6 @@ parts:
   numbered: true
   chapters:
   - file: short_path
-  - file: discrete_dp
 - caption: Job Search
   numbered: true
   chapters:
@@ -17,7 +16,6 @@ parts:
   - file: career
   - file: jv
   - file: odu
-  - file: mccall_q
 - caption: Optimal Savings
   numbered: true
   chapters:
@@ -35,6 +33,13 @@ parts:
   - file: ifp_egm
   - file: ifp_egm_transient_shocks
   - file: ifp_advanced
+- caption: Markov Decision Processes
+  numbered: true
+  chapters:
+  - file: discrete_dp
+  - file: inventory_q
+  - file: rs_inventory_q
+  - file: mccall_q
 - caption: LQ Control
   numbered: true
   chapters:


### PR DESCRIPTION
## Summary

Implements the lecture reorder agreed in #4 and finalised in [this comment thread](https://github.com/QuantEcon/lecture-dp/issues/4#issuecomment-3636739000):

- **Introduction**: drops `discrete_dp` → now contains only `short_path` (1 lecture).
- **Job Search**: drops `mccall_q` → now 8 lectures.
- **NEW section "Markov Decision Processes"** between *Income Fluctuation Problems* and *LQ Control*:
  - `discrete_dp` (moved from Introduction)
  - `inventory_q` (added in #19)
  - `rs_inventory_q` (added in #20)
  - `mccall_q` (moved from Job Search)

This is the third (and final) PR for #4. PRs #19 and #20 added the two new files to the repo but kept them out of the build (`only_build_toc_files: true`); this PR activates them and closes the reorder.

## Why this structure

`discrete_dp` is the MDP-theoretical foundation that the three Q-learning lectures build on, so grouping them together gives a coherent reading order and fixes the difficulty cliff that motivated #4 (per @jstac's note that `discrete_dp` was a lot more advanced than the introductory lectures that followed it).

## Test plan

- [ ] CI build succeeds (this is the first build with `inventory_q` / `rs_inventory_q` in the TOC).
- [ ] Generated HTML shows the new section between *Income Fluctuation Problems* and *LQ Control*.
- [ ] The 10 `{doc}` references to `inventory_q` inside `rs_inventory_q.md` resolve.
- [ ] The `{cite}\`Sargent_Stachurski_2025\`` reference in `inventory_q.md` resolves (entry added in #19).
- [ ] No internal `{doc}` references break for `discrete_dp` or `mccall_q` after the move (verified locally — no cross-references in the repo depended on their old paths).

## Follow-up

Update #7 to bump the `lecture-python.myst` mapping from 25 → 27 files.

Closes #4

🤖 Generated with [Claude Code](https://claude.com/claude-code)