### PR TITLE
Tooling scaffolding refresh: Dependabot, linkcheck, action-pin bumps

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,22 @@
+version: 2
+enable-beta-ecosystems: true     # required for the conda ecosystem
+updates:
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+    commit-message:
+      prefix: ⬆️
+  - package-ecosystem: conda
+    directory: /
+    schedule:
+      interval: weekly
+    commit-message:
+      prefix: ⬆️
+    ignore:
+      - dependency-name: jupyter-book
+        # jupyter-book 2.x is the MyST-MD rewrite and is not a drop-in
+        # upgrade for the Sphinx-based 1.x pipeline this repo uses.
+        versions: ['>=2.0']
+      - dependency-name: python
+        # Python version is constrained by the anaconda distribution

--- a/.github/workflows/cache.yml
+++ b/.github/workflows/cache.yml
@@ -3,6 +3,9 @@ on:
   schedule:
     - cron: '0 2 * * 1'  # Every Monday at 2am UTC
   workflow_dispatch:      # Manual trigger when needed
+  push:
+    branches: [main]
+    paths: [environment.yml]   # Rebuild cache when the environment changes
 
 jobs:
   build:
@@ -15,7 +18,7 @@ jobs:
       packages: read
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
       

--- a/.github/workflows/cache.yml
+++ b/.github/workflows/cache.yml
@@ -25,5 +25,5 @@ jobs:
       - name: Build and Cache Lectures
         uses: quantecon/actions/build-jupyter-cache@v0.6.0
         with:
-          builder: 'html'
+          builders: 'html'
           create-issue-on-failure: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
       packages: read
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
       
@@ -29,7 +29,7 @@ jobs:
           upload-failure-reports: true
       
       - name: Upload Build Artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: html-build
           path: ${{ steps.build.outputs.build-path }}

--- a/.github/workflows/linkcheck.yml
+++ b/.github/workflows/linkcheck.yml
@@ -1,0 +1,35 @@
+name: Link Checker
+on:
+  schedule:
+    # Weekly on Sunday 23:00 UTC (Monday morning in Australia)
+    - cron: '0 23 * * 0'
+  workflow_dispatch:
+
+jobs:
+  linkcheck:
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write              # required for peter-evans/create-issue-from-file
+    steps:
+      # This repo deploys GitHub Pages via the artifact workflow (OIDC), so
+      # there is no gh-pages branch to check out — mirror the live site instead.
+      - name: Mirror published site
+        run: |
+          wget --quiet --recursive --no-parent --no-host-directories \
+               --accept html https://dp.quantecon.org/ || true
+          find . -name '*.html' | head -5
+
+      - name: Link Checker
+        id: lychee
+        uses: lycheeverse/lychee-action@v2
+        with:
+          fail: false
+          args: --accept 403,503 '**/*.html'
+
+      - name: Create Issue From File
+        if: steps.lychee.outputs.exit_code != 0
+        uses: peter-evans/create-issue-from-file@v6
+        with:
+          title: Link Checker Report
+          content-filepath: ./lychee/out.md
+          labels: report, automated issue, linkchecker

--- a/.github/workflows/linkcheck.yml
+++ b/.github/workflows/linkcheck.yml
@@ -14,20 +14,38 @@ jobs:
       # This repo deploys GitHub Pages via the artifact workflow (OIDC), so
       # there is no gh-pages branch to check out — mirror the live site instead.
       - name: Mirror published site
+        id: mirror
         run: |
           wget --quiet --recursive --no-parent --no-host-directories \
                --accept html https://dp.quantecon.org/ || true
-          find . -name '*.html' | head -5
+          count=$(find . -name '*.html' | wc -l | tr -d ' ')
+          echo "Mirrored $count HTML file(s) from https://dp.quantecon.org/"
+          if [ "$count" -eq 0 ]; then
+            # Mirror failed (site down or wget broke). Don't run lychee against
+            # an empty mirror and report green — surface the failure instead.
+            echo "ok=false" >> "$GITHUB_OUTPUT"
+            mkdir -p lychee
+            {
+              echo "## Link Checker — mirror failed"
+              echo
+              echo "\`wget\` mirrored **0 HTML files** from https://dp.quantecon.org/, so the link check did not run."
+              echo "The live site may be down, or the mirror step may be broken — please investigate."
+            } > lychee/out.md
+          else
+            echo "ok=true" >> "$GITHUB_OUTPUT"
+          fi
 
       - name: Link Checker
         id: lychee
+        if: steps.mirror.outputs.ok == 'true'
         uses: lycheeverse/lychee-action@v2
         with:
           fail: false
           args: --accept 403,503 '**/*.html'
 
+      # Open an issue if the mirror failed, or if lychee found broken links.
       - name: Create Issue From File
-        if: steps.lychee.outputs.exit_code != 0
+        if: steps.mirror.outputs.ok != 'true' || steps.lychee.outputs.exit_code != 0
         uses: peter-evans/create-issue-from-file@v6
         with:
           title: Link Checker Report

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -26,7 +26,7 @@ jobs:
       packages: read
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
       
@@ -41,7 +41,7 @@ jobs:
           upload-failure-reports: true
       
       - name: Upload Build Artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: html-build
           path: ${{ steps.build.outputs.build-path }}
@@ -59,7 +59,7 @@ jobs:
       url: ${{ steps.deployment.outputs.page-url }}
     steps:
       - name: Download Build Artifact
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v6
         with:
           name: html-build
           path: _build/html

--- a/environment.yml
+++ b/environment.yml
@@ -11,7 +11,7 @@ dependencies:
     - sphinx-tojupyter==0.6.0
     - sphinxext-rediraffe==0.3.0
     - sphinx-exercise==1.2.1
-    - sphinx-proof==0.3.0
-    - sphinxcontrib-youtube==1.4.1
-    - sphinx-togglebutton==0.3.2
+    - sphinx-proof==0.4.0
+    - sphinxcontrib-youtube==1.5.0
+    - sphinx-togglebutton==0.4.5
     - sphinx-reredirects==1.1.0

--- a/lectures/_config.yml
+++ b/lectures/_config.yml
@@ -87,8 +87,6 @@ sphinx:
       og_logo_url: https://assets.quantecon.org/img/qe-og-logo.png
       description: This website presents a set of lectures on dynamic programming, designed and written by Thomas J. Sargent and John Stachurski.
       keywords: Python, QuantEcon, Quantitative Economics, Economics, Dynamic Programming, Tom J. Sargent, John Stachurski
-      analytics:
-        google_analytics_id: G-XXXXXXXXXX
       launch_buttons:
         colab_url                 : https://colab.research.google.com
     intersphinx_mapping: 


### PR DESCRIPTION
Part of #22 — the mechanical "Bucket A" items that need no maintainer decisions.

## What's in here

| Change | Why |
|---|---|
| **New `.github/dependabot.yml`** (github-actions + conda, weekly, with the `jupyter-book >=2.0` ignore) | The highest-value item: in the last fortnight Dependabot auto-delivered to `lecture-python-advanced.myst` the exact sphinx-extension bumps this repo missed. Without it this repo drifts silently. |
| **New `linkcheck.yml`** (weekly lychee run) | Dead links currently go undetected indefinitely. ⚠️ Note: this repo deploys Pages via the **OIDC artifact workflow, so there is no `gh-pages` branch** — the workflow mirrors the live site (`dp.quantecon.org`) with wget instead of the checkout-gh-pages pattern other lecture repos use. |
| `actions/checkout` v4→v6, `upload-artifact` v4→v7, `download-artifact` v4→v6 | Catch up to current majors; Dependabot maintains them from here. |
| `cache.yml`: rebuild on `environment.yml` change (push to main) | Previously the build cache stayed stale for up to a week after an env change, so PRs built against an outdated cache. |
| `environment.yml`: `sphinx-proof` 0.3.0→0.4.0, `sphinxcontrib-youtube` 1.4.1→1.5.0, `sphinx-togglebutton` 0.3.2→0.4.5 | Stale pins copied from an older repo's env; these are the versions the sibling lecture repos run with the same `jupyter-book` pin. |
| Remove placeholder `google_analytics_id: G-XXXXXXXXXX` | Non-functional placeholder; re-add with a real GA4 measurement ID if analytics are wanted. |

## Deliberately NOT in here

- **`quantecon-book-theme==0.15.1` is untouched** — 0.21.0 ships a layout overhaul and needs a visual review; tracked in #23.
- PR preview deploy (#24) and PDF/notebook publishing (#25) — decisions pending.
- `quantecon/actions/*@v0.6.0` pins — unchanged pending a QuantEcon/actions v1.0 release (tracked in #22).

## Validation

- CI on this PR runs the full container build with the bumped extension pins.
- `linkcheck.yml` is schedule + `workflow_dispatch`; it can be smoke-tested from the Actions tab after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)