### PR TITLE
SYNC: update short_path.md from lecture-python-intro

### DIFF
--- a/lectures/short_path.md
+++ b/lectures/short_path.md
@@ -142,7 +142,7 @@ implement it.
 
 ### The algorithm
 
-The standard algorithm for finding $J$ is to start an initial guess and then iterate.
+The standard algorithm for finding $J$ is to start with an initial guess and then iterate.
 
 This is a standard approach to solving nonlinear equations, often called
 the method of **successive approximations**.


### PR DESCRIPTION
Brings `lectures/short_path.md` back into byte-identical alignment with its primary source (see #7). Upstream landed a single-word fix:

\`\`\`diff
- The standard algorithm for finding \$J\$ is to start an initial guess and then iterate.
+ The standard algorithm for finding \$J\$ is to start with an initial guess and then iterate.
\`\`\`

No intersphinx prefixes to preserve; `short_path.md` is not in #7's exception list.

🤖 Generated with [Claude Code](https://claude.com/claude-code)