### PR TITLE
Set interim site base URL to the github.io Pages default

### DIFF
--- a/lectures/_config.yml
+++ b/lectures/_config.yml
@@ -25,7 +25,7 @@ bibtex_bibfiles:
    - _static/quant-econ.bib
 
 html:
-  baseurl: https://dp.quantecon.org/
+  baseurl: https://quantecon.github.io/lecture-dp/
 
 latex:
    latex_documents:
@@ -117,8 +117,8 @@ sphinx:
       index_toc.md: intro.md
     tojupyter_static_file_path: ["source/_static", "_static"]
     tojupyter_target_html: true
-    tojupyter_urlpath: "https://dp.quantecon.org/"
-    tojupyter_image_urlpath: "https://dp.quantecon.org/_static/"
+    tojupyter_urlpath: "https://quantecon.github.io/lecture-dp/"
+    tojupyter_image_urlpath: "https://quantecon.github.io/lecture-dp/_static/"
     tojupyter_lang_synonyms: ["ipython", "ipython3", "python"]
     tojupyter_kernels:
       python3:


### PR DESCRIPTION
## What

Points the site base URL at the current GitHub Pages host, `https://quantecon.github.io/lecture-dp/`, as an **interim** setting.

## Why

The DP lectures are currently served at `https://quantecon.github.io/lecture-dp/` (Pages `cname` is null), but `lectures/_config.yml` still pointed at `https://dp.quantecon.org/`, which now serves a **separate book landing page**. That mismatch bakes `dp.quantecon.org` links into the build that all 404:

- `html.baseurl` → canonical + absolute self-links between lecture pages
- `tojupyter_urlpath` → URLs written into the **downloadable notebooks**
- `tojupyter_image_urlpath` → image URLs in the downloadable notebooks

A quick check confirms the mismatch: `https://dp.quantecon.org/intro.html` → **404**, while `https://quantecon.github.io/lecture-dp/intro.html` → **200**.

## Change

Three keys in `lectures/_config.yml`, `https://dp.quantecon.org/` → `https://quantecon.github.io/lecture-dp/` (and the `/_static/` variant).

## Interim, pending the final URL

This is deliberately a stopgap so the published site's internal links and notebook URLs resolve today. The permanent custom URL is still being decided in #2 — this should be revisited (and updated once more) when that lands.

## Related

- Unblocks the link-check fix in #39: once this merges and the site is re-published, the release tarball's self-links resolve to the github.io host (200), so the linkcheck reports clean instead of ~73 `dp.quantecon.org` 404s.
- Tracking issue for the final URL: #2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
