### PR TITLE
Adopt minimal proof/exercise styling

### DIFF
--- a/lectures/_config.yml
+++ b/lectures/_config.yml
@@ -37,6 +37,10 @@ sphinx:
     bibtex_reference_style: author_year
     suppress_warnings: ["mystnb.unknown_mime_type"]
     nb_merge_streams: true
+    # sphinx-proof
+    proof_minimal_theme: true
+    # sphinx-exercise
+    exercise_style: "solution_follow_exercise"
     nb_mime_priority_overrides: [
        # HTML
        ['html', 'application/vnd.jupyter.widget-view+json', 10],


### PR DESCRIPTION
## What

Adopt the QuantEcon **minimal** proof/exercise styling in `lectures/_config.yml`:

- `proof_minimal_theme: true` — sphinx-proof minimal theme
- `exercise_style: "solution_follow_exercise"` — sphinx-exercise layout

## Why

Part of a cross-series harmonization so every Python lecture series presents proofs and exercises with the same minimal look. `dp` was the only series opting out of **both** knobs. See the audit and checklist in QuantEcon/workspace-lectures#13.

## Note

Config-only change; no lecture content touched.
