### PR TITLE
⬆️ Bump anaconda from 2026.06 to 2026.07

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -3,7 +3,7 @@ channels:
   - default
 dependencies:
   - python=3.13
-  - anaconda=2026.06
+  - anaconda=2026.07
   - pip
   - pip:
     - jupyter-book>=1.0.4post1,<2.0


### PR DESCRIPTION
Rolling monthly bump of the conda env pin `anaconda=2026.06 → 2026.07`.

## Why this is hand-authored rather than a Dependabot PR

Dependabot assigns each repo a fixed weekly slot, and this repo's slot had not yet fired for the 2026.07 release. The rest of the Python lecture family has already been bumped, validated and merged, so this opens the PR by hand to finish the sweep rather than waiting several more days.

If Dependabot later opens its own PR for the same bump it will not recognise this one, so that duplicate should be closed (as happened with lecture-python-advanced.myst#349 during the 2026.06 round).

## Validation

The `pull_request` CI check is **not** a meaningful test of an env-only bump — it downloads the `main` build-cache artifact and reuses the cached notebook outputs, so it skips re-executing the notebooks under the new env entirely. A green check there proves nothing about the upgrade.

The canonical signal is a `cache.yml` dispatch on this branch, which does a full fresh `jb build lectures -W --keep-going` (warnings→errors) executing every notebook under 2026.07. I have dispatched that run and will report the result here.

## Known 2026.07 breakage — pre-checked

The one regression found so far in this sweep is that anaconda 2026.07's matplotlib removes the long-deprecated `matplotlib.cm.get_cmap`, which raises `ImportError` at import time and kills the whole notebook (hit lecture-python-intro `laffer_adaptive.md`, fixed in QuantEcon/lecture-python-intro#798). I grepped this repo's `lectures/` for that pattern before opening — no hits.

Cross-repo status for this sweep is tracked in QuantEcon/workspace-lectures#21.
